### PR TITLE
fix(vscode): publish extension with Miragon logo icon

### DIFF
--- a/vscode/apps/vscode/egon-modeler-plugin/package.json
+++ b/vscode/apps/vscode/egon-modeler-plugin/package.json
@@ -30,7 +30,7 @@
   "engines": {
     "vscode": "^1.76.0"
   },
-  "icon": "assets/egon-io-logo.png",
+  "icon": "assets/miragon-logo.png",
   "categories": [
     "Visualization",
     "Other"

--- a/vscode/apps/vscode/egon-modeler-plugin/webpack.config.js
+++ b/vscode/apps/vscode/egon-modeler-plugin/webpack.config.js
@@ -117,8 +117,8 @@ module.exports = (env, argv) => {
                         to: ".",
                     },
                     {
-                        from: "egon-io-logo.png",
-                        to: "assets/egon-io-logo.png",
+                        from: "miragon-logo.png",
+                        to: "assets/miragon-logo.png",
                         context: path.resolve(__dirname, "../../../images"),
                     },
                     {


### PR DESCRIPTION
## What

Changes the VS Code extension's marketplace icon from the Egon.io logo to the **Miragon logo** — the same icon used by [Miragon/bpmn-modeler](https://github.com/Miragon/bpmn-modeler).

## Why

For a consistent brand appearance across Miragon's VS Code extensions on the marketplace.

## Changes

- `apps/vscode/egon-modeler-plugin/package.json` — `icon` now points to `assets/miragon-logo.png`
- `apps/vscode/egon-modeler-plugin/webpack.config.js` — bundles `images/miragon-logo.png` into `assets/` at build time

The `images/miragon-logo.png` asset already existed in the repo and is byte-identical (matching SHA-256) to the icon `Miragon/bpmn-modeler` publishes. The Egon.io logo remains in use elsewhere (README, diagram-js assets) and was left untouched.